### PR TITLE
added dir elements for Kodi 20

### DIFF
--- a/repository.sendtokodi.python3/addon.xml
+++ b/repository.sendtokodi.python3/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.sendtokodi.python3" name="SendToKodi Add-ons" version="0.0.1" provider-name="firsttris">
 	<extension point="xbmc.addon.repository" name="SendToKodi Python 3 Add-on Repository">
-		<info compressed="false">https://raw.githubusercontent.com/firsttris/repository.sendtokodi.python3/master/addon.xml</info>
-		<checksum>https://raw.githubusercontent.com/firsttris/repository.sendtokodi.python3/master/addon.xml.md5</checksum>
-		<datadir zip="true">https://raw.githubusercontent.com/firsttris/repository.sendtokodi.python3/master/</datadir>
+		<dir>
+			<info compressed="false">https://raw.githubusercontent.com/firsttris/repository.sendtokodi.python3/master/addon.xml</info>
+			<checksum>https://raw.githubusercontent.com/firsttris/repository.sendtokodi.python3/master/addon.xml.md5</checksum>
+			<datadir zip="true">https://raw.githubusercontent.com/firsttris/repository.sendtokodi.python3/master/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">SendToKodi Add-on Repository</summary>


### PR DESCRIPTION
Kodi 20 doesn't support an addon.xml in repository addons without dir element wraps. See <https://kodi.wiki/view/Add-on_repositories#Repository_Add-on>.

Without the wraps the repository won't work, kodi.log error:

```
error <general>: GetDirectory - Error getting addons://repository.sendtokodi.python3/
error <general>: CGUIMediaWindow::GetDirectory(addons://repository.sendtokodi.python3/) failed
error <general>: Repository add-on repository.sendtokodi.python3 uses old schema definition for the repository extension point! This is no longer supported, please update your addon to use <dir> definitions.
error <general>: Repository add-on repository.sendtokodi.python3 does not have any directory and won't be able to update/serve addons! Please fix the addon.xml definition
```

Tested on my Kodi installation, repository updates after Kodi restart, no error messages in log anymore.