### PR TITLE
Remove redundant addon element

### DIFF
--- a/addon.template.xml
+++ b/addon.template.xml
@@ -9,25 +9,4 @@
         <platform>all</platform>
 	</extension>
 </addon>
-
-<addon id="plugin.video.sendtokodi" name="sendtokodi" version="$VERSION" provider-name="firsttris">
-    <requires>
-        <import addon="xbmc.python" version="3.0.0"/>
-	<import addon="script.module.inputstreamhelper" version="0.4.2"/>
-    </requires>
-    <extension point="xbmc.python.pluginsource" library="service.py">
-        <provides>video</provides>
-    </extension>
-    <extension point="xbmc.addon.metadata">
-        <summary lang="en">SendToKodi</summary>
-        <description lang="en">SendToKodi</description>
-        <description lang="de">SendToKodi</description>
-        <disclaimer lang="en"></disclaimer>
-        <platform>all</platform>
-        <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-        <website>https://teufel-it.de/</website>
-        <email>info@teufel-it.de</email>
-        <source>https://github.com/firsttris/</source>
-    </extension>
-</addon>
 </addons>


### PR DESCRIPTION
The addon's `addon` element is being fetched and added directly from upstream, avoiding update anomalies.

Dependent: https://github.com/firsttris/plugin.video.sendtokodi/pull/147